### PR TITLE
fix: handle non-string dict keys from YAML parsing

### DIFF
--- a/ifstruct/validator.py
+++ b/ifstruct/validator.py
@@ -305,8 +305,8 @@ def validate_against_json_schema(data: Any, schema: dict[str, Any], path: str = 
                 field_path = f"{path}.{field_name}" if path else field_name
                 checks.extend(validate_against_json_schema(data[field_name], field_schema, field_path))
         extra_keys = set(data.keys()) - set(properties.keys())
-        for key in sorted(extra_keys):
-            field_path = f"{path}.{key}" if path else key
+        for key in sorted(extra_keys, key=str):
+            field_path = f"{path}.{str(key)}" if path else str(key)
             checks.append(FieldCheck(field_path, False, f"extraneous field '{key}'"))
         return checks
 


### PR DESCRIPTION
## Summary

- `yaml.SafeLoader` converts bare YAML keywords (`true`, `false`, `yes`, `no`) to Python types — including in dict **keys**
- When a model response contains `true:` as a YAML key, the parsed dict has `{True: ..., "name": ...}` (mixed `bool` + `str` keys)
- `sorted()` on mixed types raises `TypeError` in Python 3, crashing `validate_against_json_schema` instead of scoring the sample as failed

## Fix

`sorted(extra_keys, key=str)` — keys are cast to string for comparison. The extraneous field is correctly flagged and the sample scores as failed.

## Reproducer

```python
from ifstruct.validator import validate_against_json_schema

data = {True: 'value', 'name': 'Alice'}  # what yaml.load produces
schema = {'type': 'object', 'properties': {'name': {'type': 'string'}}, 'required': ['name']}

# Before fix: TypeError: '<' not supported between instances of 'str' and 'bool'
# After fix: [FieldCheck(path='name', passed=True), FieldCheck(path='True', passed=False, error="extraneous field 'True'")]
validate_against_json_schema(data, schema)
```